### PR TITLE
Add Darbot modules to packaging

### DIFF
--- a/docs/darbot/building-modules.md
+++ b/docs/darbot/building-modules.md
@@ -1,0 +1,11 @@
+# Building Darbot Modules
+
+The build system can package `Darbot.MCP` and `Darbot.NLWeb` as optional modules.
+These modules are restored from the PowerShell Gallery when `Start-PSBuild` is
+run with module restore enabled.
+
+1. Ensure the repository is bootstrapped as described in the standard build
+documentation.
+2. Run `Start-PSBuild -PSModuleRestore` to fetch the modules.
+3. Use `Start-PSPackage` to create packages. The modules will appear under the
+`Modules` folder of the output and can be distributed separately.

--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -17,7 +17,9 @@
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
     <PackageReference Include="PSReadLine" Version="2.3.6" />
     <PackageReference Include="ThreadJob" Version="2.1.0" />
-    <PackageReference Include="Microsoft.PowerShell.ThreadJob" Version="2.2.0" />   
+    <PackageReference Include="Microsoft.PowerShell.ThreadJob" Version="2.2.0" />
+    <PackageReference Include="Darbot.MCP" Version="0.1.0" />
+    <PackageReference Include="Darbot.NLWeb" Version="0.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Modules/Unix/Darbot.MCP/Darbot.MCP.psd1
+++ b/src/Modules/Unix/Darbot.MCP/Darbot.MCP.psd1
@@ -1,0 +1,10 @@
+@{
+    GUID = "11111111-1111-1111-1111-111111111111"
+    Author = "Darbot"
+    CompanyName = "Darbot"
+    ModuleVersion = "0.1.0"
+    CompatiblePSEditions = @("Core")
+    PowerShellVersion = "3.0"
+    RootModule = "Darbot.MCP.psm1"
+    FunctionsToExport = @()
+}

--- a/src/Modules/Unix/Darbot.MCP/Darbot.MCP.psm1
+++ b/src/Modules/Unix/Darbot.MCP/Darbot.MCP.psm1
@@ -1,0 +1,1 @@
+# Placeholder for Darbot.MCP module

--- a/src/Modules/Unix/Darbot.NLWeb/Darbot.NLWeb.psd1
+++ b/src/Modules/Unix/Darbot.NLWeb/Darbot.NLWeb.psd1
@@ -1,0 +1,10 @@
+@{
+    GUID = "22222222-2222-2222-2222-222222222222"
+    Author = "Darbot"
+    CompanyName = "Darbot"
+    ModuleVersion = "0.1.0"
+    CompatiblePSEditions = @("Core")
+    PowerShellVersion = "3.0"
+    RootModule = "Darbot.NLWeb.psm1"
+    FunctionsToExport = @()
+}

--- a/src/Modules/Unix/Darbot.NLWeb/Darbot.NLWeb.psm1
+++ b/src/Modules/Unix/Darbot.NLWeb/Darbot.NLWeb.psm1
@@ -1,0 +1,1 @@
+# Placeholder for Darbot.NLWeb module

--- a/src/Modules/Windows/Darbot.MCP/Darbot.MCP.psd1
+++ b/src/Modules/Windows/Darbot.MCP/Darbot.MCP.psd1
@@ -1,0 +1,10 @@
+@{
+    GUID = "11111111-1111-1111-1111-111111111111"
+    Author = "Darbot"
+    CompanyName = "Darbot"
+    ModuleVersion = "0.1.0"
+    CompatiblePSEditions = @("Core")
+    PowerShellVersion = "3.0"
+    RootModule = "Darbot.MCP.psm1"
+    FunctionsToExport = @()
+}

--- a/src/Modules/Windows/Darbot.MCP/Darbot.MCP.psm1
+++ b/src/Modules/Windows/Darbot.MCP/Darbot.MCP.psm1
@@ -1,0 +1,1 @@
+# Placeholder for Darbot.MCP module

--- a/src/Modules/Windows/Darbot.NLWeb/Darbot.NLWeb.psd1
+++ b/src/Modules/Windows/Darbot.NLWeb/Darbot.NLWeb.psd1
@@ -1,0 +1,10 @@
+@{
+    GUID = "22222222-2222-2222-2222-222222222222"
+    Author = "Darbot"
+    CompanyName = "Darbot"
+    ModuleVersion = "0.1.0"
+    CompatiblePSEditions = @("Core")
+    PowerShellVersion = "3.0"
+    RootModule = "Darbot.NLWeb.psm1"
+    FunctionsToExport = @()
+}

--- a/src/Modules/Windows/Darbot.NLWeb/Darbot.NLWeb.psm1
+++ b/src/Modules/Windows/Darbot.NLWeb/Darbot.NLWeb.psm1
@@ -1,0 +1,1 @@
+# Placeholder for Darbot.NLWeb module

--- a/tools/packaging/boms/linux.json
+++ b/tools/packaging/boms/linux.json
@@ -2442,5 +2442,21 @@
   {
     "Pattern": "System.Management.Automation.dll",
     "FileType": "Product"
+  },
+  {
+    "Pattern": "Modules/Darbot.MCP/.*.psd1",
+    "FileType": "Product"
+  },
+  {
+    "Pattern": "Modules/Darbot.MCP/.*.psm1",
+    "FileType": "Product"
+  },
+  {
+    "Pattern": "Modules/Darbot.NLWeb/.*.psd1",
+    "FileType": "Product"
+  },
+  {
+    "Pattern": "Modules/Darbot.NLWeb/.*.psm1",
+    "FileType": "Product"
   }
 ]

--- a/tools/packaging/boms/mac.json
+++ b/tools/packaging/boms/mac.json
@@ -2218,5 +2218,21 @@
   {
     "Pattern": "System.Management.Automation.dll",
     "FileType": "Product"
+  },
+  {
+    "Pattern": "Modules/Darbot.MCP/.*.psd1",
+    "FileType": "Product"
+  },
+  {
+    "Pattern": "Modules/Darbot.MCP/.*.psm1",
+    "FileType": "Product"
+  },
+  {
+    "Pattern": "Modules/Darbot.NLWeb/.*.psd1",
+    "FileType": "Product"
+  },
+  {
+    "Pattern": "Modules/Darbot.NLWeb/.*.psm1",
+    "FileType": "Product"
   }
 ]

--- a/tools/packaging/boms/windows.json
+++ b/tools/packaging/boms/windows.json
@@ -3527,5 +3527,21 @@
   {
     "Pattern": "System.Management.Automation.dll",
     "FileType": "Product"
+  },
+  {
+    "Pattern": "Modules\Darbot.MCP\.*.psd1",
+    "FileType": "Product"
+  },
+  {
+    "Pattern": "Modules\Darbot.MCP\.*.psm1",
+    "FileType": "Product"
+  },
+  {
+    "Pattern": "Modules\Darbot.NLWeb\.*.psd1",
+    "FileType": "Product"
+  },
+  {
+    "Pattern": "Modules\Darbot.NLWeb\.*.psm1",
+    "FileType": "Product"
   }
 ]

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2378,14 +2378,18 @@ function New-ILNugetPackageSource
             "Microsoft.PowerShell.Security",
             "Microsoft.PowerShell.Utility",
             "Microsoft.WSMan.Management",
-            "PSDiagnostics"
+            "PSDiagnostics",
+            "Darbot.MCP",
+            "Darbot.NLWeb"
         )
 
         $unixBuiltInModules = @(
             "Microsoft.PowerShell.Host",
             "Microsoft.PowerShell.Management",
             "Microsoft.PowerShell.Security",
-            "Microsoft.PowerShell.Utility"
+            "Microsoft.PowerShell.Utility",
+            "Darbot.MCP",
+            "Darbot.NLWeb"
         )
 
         $winModuleFolder = New-Item (Join-Path $contentFolder "runtimes\win\lib\$script:netCoreRuntime\Modules") -ItemType Directory -Force


### PR DESCRIPTION
## Summary
- include Darbot.MCP and Darbot.NLWeb as optional modules
- add placeholder module manifests
- copy new modules into packaging BOMs
- restore modules via PSGallery project
- document building modules

## Testing
- `pwsh -NoProfile -Command "Write-Host hi"` *(fails: command not found)*